### PR TITLE
Get pairs direct mid price on Sushiswap

### DIFF
--- a/listener/src/dexs/sushiswap/sushiswap.test.ts
+++ b/listener/src/dexs/sushiswap/sushiswap.test.ts
@@ -59,7 +59,6 @@ describe("createPair", () => {
     expect(token1["address"]).toBe(TOKENS.USDT.mainnet);
   });
 
-
   it("should create WETH/BNB pair with the correct token info", async () => {
     const pair = await createPair(WETH, BNB, provider);
     const [tokenAmount0, tokenAmount1] = pair["tokenAmounts"];

--- a/listener/src/dexs/sushiswap/sushiswap.test.ts
+++ b/listener/src/dexs/sushiswap/sushiswap.test.ts
@@ -44,7 +44,7 @@ describe("createPair", () => {
     expect(pair).toBeDefined();
   });
 
-  it("should create WETH/USDT pair with the correct token info", async () => {
+  it("should create WETH/USDT pair with the correct pair info", async () => {
     const pair = await createPair(WETH, USDT, provider);
     const [tokenAmount0, tokenAmount1] = pair["tokenAmounts"];
 
@@ -59,7 +59,7 @@ describe("createPair", () => {
     expect(token1["address"]).toBe(TOKENS.USDT.mainnet);
   });
 
-  it("should create WETH/BNB pair with the correct token info", async () => {
+  it("should create WETH/BNB pair with the correct pair info", async () => {
     const pair = await createPair(WETH, BNB, provider);
     const [tokenAmount0, tokenAmount1] = pair["tokenAmounts"];
 

--- a/listener/src/dexs/sushiswap/sushiswap.test.ts
+++ b/listener/src/dexs/sushiswap/sushiswap.test.ts
@@ -1,6 +1,6 @@
 import { TOKENS } from "../../constants";
 import { ChainId, Token } from "@uniswap/sdk-core";
-import { createPair } from "./sushiswap";
+import { createPair, getMidPrice } from "./sushiswap";
 import { ethers } from "ethers";
 
 let USDT: Token;
@@ -50,8 +50,6 @@ describe("createPair", () => {
 
     const token0 = tokenAmount0["currency"];
     const token1 = tokenAmount1["currency"];
-    console.log("token0", token0);
-    console.log("token1", token1);
 
     expect(token0["symbol"]).toBe("WETH");
     expect(token0["decimals"]).toBe(18);
@@ -64,13 +62,10 @@ describe("createPair", () => {
 
   it("should create WETH/BNB pair with the correct token info", async () => {
     const pair = await createPair(WETH, BNB, provider);
-    console.log("tokenAmounts", pair["tokenAmounts"]);
     const [tokenAmount0, tokenAmount1] = pair["tokenAmounts"];
 
     const token0 = tokenAmount0["currency"];
     const token1 = tokenAmount1["currency"];
-    console.log("token0", token0);
-    console.log("token1", token1);
 
     expect(token0["symbol"]).toBe("BNB");
     expect(token0["decimals"]).toBe(18);
@@ -78,5 +73,12 @@ describe("createPair", () => {
     expect(token1["symbol"]).toBe("WETH");
     expect(token1["decimals"]).toBe(18);
     expect(token1["address"]).toBe(TOKENS.WETH.mainnet);
+  });
+});
+
+describe("getMidPrice", () => {
+  it("should return WETH token price in USDT", async () => {
+    const midPrice = await getMidPrice(WETH, USDT, provider);
+    expect(midPrice).toBeCloseTo(3777.25, -1);
   });
 });

--- a/listener/src/dexs/sushiswap/sushiswap.ts
+++ b/listener/src/dexs/sushiswap/sushiswap.ts
@@ -1,5 +1,5 @@
 import { Token, CurrencyAmount, TradeType } from "@uniswap/sdk-core";
-import { Pair } from "@uniswap/v2-sdk";
+import { Pair, Route } from "@uniswap/v2-sdk";
 import { ethers } from "ethers";
 import { ABI } from "./abi";
 
@@ -19,7 +19,7 @@ export async function createPair(
     provider
   );
 
-  const reserves = await pairContract.getReserves();
+  const reserves = await pairContract["getReserves"]();
   const [reserve0, reserve1] = reserves;
 
   const tokens = [token0, token1];
@@ -37,6 +37,17 @@ export async function createPair(
   );
 
   return pair;
+}
+
+export async function getMidPrice(
+  inputToken: Token,
+  outputToken: Token,
+  provider: ethers.JsonRpcProvider
+): Promise<number> {
+  const pair = await createPair(inputToken, outputToken, provider);
+  const route = new Route([pair], inputToken, outputToken);
+
+  return Number(route.midPrice.toSignificant(6));
 }
 
 function getPairAddress(tokenA: Token, tokenB: Token): string {

--- a/listener/src/dexs/uniswap/uniswap.test.ts
+++ b/listener/src/dexs/uniswap/uniswap.test.ts
@@ -44,7 +44,7 @@ describe("createPair", () => {
     expect(pair).toBeDefined();
   });
 
-  it("should create a pair with the correct token info", async () => {
+  it("should create WETH/USDT pair with the correct pair info", async () => {
     const pair = await createPair(WETH, USDT, provider);
     const [tokenAmount0, tokenAmount1] = pair["tokenAmounts"];
 
@@ -57,6 +57,21 @@ describe("createPair", () => {
     expect(token1["symbol"]).toBe("USDT");
     expect(token1["decimals"]).toBe(6);
     expect(token1["address"]).toBe(TOKENS.USDT.mainnet);
+  });
+
+  it("should create WETH/BNB pair with the correct pair info", async () => {
+    const pair = await createPair(WETH, BNB, provider);
+    const [tokenAmount0, tokenAmount1] = pair["tokenAmounts"];
+
+    const token0 = tokenAmount0["currency"];
+    const token1 = tokenAmount1["currency"];
+
+    expect(token0["symbol"]).toBe("BNB");
+    expect(token0["decimals"]).toBe(18);
+    expect(token0["address"]).toBe(TOKENS.BNB.mainnet);
+    expect(token1["symbol"]).toBe("WETH");
+    expect(token1["decimals"]).toBe(18);
+    expect(token1["address"]).toBe(TOKENS.WETH.mainnet);
   });
 });
 


### PR DESCRIPTION
Implement a function to fetch a token's price, given the input and output tokens, when there's a direct pair between the two tokens. The case where there's no direct pair between the two, and we need to use an indirect route, will be tackled in a future PR.

_______________________________________________

Example of usage:

`getMidPrice(WETH, USDT, provider) -> 3777.25`

_______________________________________________

Similar PR: https://github.com/aantoniorodrigues/arbitrage_bot/pull/11

